### PR TITLE
test: cover local feed pagination browser paths

### DIFF
--- a/lib/benchmark.ex
+++ b/lib/benchmark.ex
@@ -66,120 +66,96 @@ defmodule Bonfire.UI.Social.Benchmark do
         Bonfire.Social.FeedActivities.feed(:local, limit: 20, skip_boundary_check: true)
       end,
       "query 1 with 1 year time limit" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 365)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 1)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(365, limit: 1)
       end,
       "query 10 with 1 year time limit" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 365)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 10)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(365, limit: 10)
       end,
       "query 20 with 1 year time limit" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 365)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 20)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(365, limit: 20)
       end,
       "query 1 with 1 year time limit, without boundaries" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 365)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 1, skip_boundary_check: true)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(365, limit: 1, skip_boundary_check: true)
       end,
       "query 10 with 1 year time limit, without boundaries" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 365)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 10, skip_boundary_check: true)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(365, limit: 10, skip_boundary_check: true)
       end,
       "query 20 with 1 year time limit, without boundaries" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 365)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 20, skip_boundary_check: true)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(365, limit: 20, skip_boundary_check: true)
       end,
       "query 1 with no time limit" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 1, query_with_deferred_join: false)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(0, limit: 1)
       end,
       "query 10 with no time limit" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 10, query_with_deferred_join: false)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(0, limit: 10)
       end,
       "query 20 with no time limit" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 20, query_with_deferred_join: false)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(0, limit: 20)
+      end,
+      "query 1 with no time limit, without deferred join" => fn ->
+        feed_with_time_limit(0, limit: 1, query_with_deferred_join: false)
+      end,
+      "query 10 with no time limit, without deferred join" => fn ->
+        feed_with_time_limit(0, limit: 10, query_with_deferred_join: false)
+      end,
+      "query 20 with no time limit, without deferred join" => fn ->
+        feed_with_time_limit(0, limit: 20, query_with_deferred_join: false)
       end,
       "query 1 with no time limit, with boundaries view" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-
-        Bonfire.Social.FeedActivities.feed(:local,
+        feed_with_time_limit(0,
           limit: 1,
           query_with_deferred_join: false,
           boundarise_with_view: true
         )
-
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
       end,
       "query 10 with no time limit, with boundaries view" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-
-        Bonfire.Social.FeedActivities.feed(:local,
+        feed_with_time_limit(0,
           limit: 10,
           query_with_deferred_join: false,
           boundarise_with_view: true
         )
-
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
       end,
       "query 20 with no time limit, with boundaries view" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-
-        Bonfire.Social.FeedActivities.feed(:local,
+        feed_with_time_limit(0,
           limit: 20,
           query_with_deferred_join: false,
           boundarise_with_view: true
         )
-
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
       end,
       "query 1 with no time limit, with deferred join" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 1, query_with_deferred_join: true)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(0, limit: 1, query_with_deferred_join: true)
       end,
       "query 10 with no time limit, with deferred join" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 10, query_with_deferred_join: true)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(0, limit: 10, query_with_deferred_join: true)
       end,
       "query 20 with no time limit, with deferred join" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 20, query_with_deferred_join: true)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(0, limit: 20, query_with_deferred_join: true)
       end,
       "query 1 with no time limit, ignoring boundaries" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 1, skip_boundary_check: true)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(0, limit: 1, skip_boundary_check: true)
       end,
       "query 10 with no time limit, ignoring boundaries" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 10, skip_boundary_check: true)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(0, limit: 10, skip_boundary_check: true)
       end,
       "query 20 with no time limit, ignoring boundaries" => fn ->
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-        Bonfire.Social.FeedActivities.feed(:local, limit: 20, skip_boundary_check: true)
-        Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+        feed_with_time_limit(0, limit: 20, skip_boundary_check: true)
       end
     }
   end
 
+  defp feed_with_time_limit(days, opts) do
+    previous = Config.get([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+    Config.put([Bonfire.UI.Social.FeedLive, :time_limit], days)
+
+    try do
+      Bonfire.Social.FeedActivities.feed(:local, opts)
+    after
+      Config.put([Bonfire.UI.Social.FeedLive, :time_limit], previous)
+    end
+  end
+
   def feed_full_backend do
-    Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
-    Bonfire.Social.FeedActivities.feed(:local, limit: 20)
-    Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+    feed_with_time_limit(0, limit: 20)
   end
 
   # defp current_user_approaches_feed do

--- a/lib/components/activity/actions/more_actions_live.sface
+++ b/lib/components/activity/actions/more_actions_live.sface
@@ -228,7 +228,7 @@
               [
                 "flag",
                 l("this %{object}", object: @object_type_readable || l("object")),
-                @permalink || URIs.canonical_url(@object),
+                @permalink || URIs.canonical_url(@object, preload_if_needed: false),
                 @__context__
               ],
               fallback_return: "/login"

--- a/lib/live_handlers/feeds_live_handler.ex
+++ b/lib/live_handlers/feeds_live_handler.ex
@@ -644,7 +644,7 @@ defmodule Bonfire.Social.Feeds.LiveHandler do
        previous_page_info: e(opts, :page_info, nil),
        page_info: e(feed, :page_info, []),
        loading: true,
-       #  feed_filters: filters,
+       feed_filters: filters,
        activity_preloads: preloads
      )
      |> insert_feed(e(feed, :edges, []), opts)}

--- a/test/views/pagination/deferred_join_actual_cases_test.exs
+++ b/test/views/pagination/deferred_join_actual_cases_test.exs
@@ -1,0 +1,171 @@
+defmodule Bonfire.UI.Social.Feeds.DeferredJoinActualCasesTest do
+  use Bonfire.UI.Social.ConnCase, async: false
+  @moduletag :ui
+
+  use Bonfire.Common.Config
+
+  alias Bonfire.Classify.Simulate
+  alias Bonfire.Posts
+
+  setup do
+    account = fake_account!()
+    viewer = fake_user!(account)
+    other_user = fake_user!()
+
+    original_deferred = Config.get([Bonfire.Social.Feeds, :query_with_deferred_join])
+    Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], true)
+
+    on_exit(fn ->
+      Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], original_deferred)
+    end)
+
+    repo().delete_all(Bonfire.Data.Social.FeedPublish)
+
+    %{account: account, viewer: viewer, other_user: other_user}
+  end
+
+  test "group feed load_more stays scoped with deferred join and unrelated activity noise", %{
+    account: account,
+    viewer: viewer,
+    other_user: other_user
+  } do
+    limit = Bonfire.Common.Config.get(:default_pagination_limit, 2)
+    group_marker = "GROUP_DEFERRED_#{System.unique_integer([:positive])}"
+    unrelated_marker = "GROUP_UNRELATED_#{System.unique_integer([:positive])}"
+    private_marker = "GROUP_PRIVATE_#{System.unique_integer([:positive])}"
+
+    group =
+      Simulate.fake_group!(viewer, %{
+        name: "Deferred Group",
+        membership: "local:members",
+        visibility: "nonfederated",
+        participation: "anyone"
+      })
+
+    group_markers =
+      for n <- 1..(limit * 3) do
+        marker = "#{group_marker}_#{n}_END"
+        Simulate.fake_post_in_group!(viewer, group, "<p>#{marker}</p>")
+        marker
+      end
+
+    create_public_noise(viewer, unrelated_marker, limit * 3)
+    create_private_noise(other_user, private_marker, limit * 12)
+
+    session =
+      conn(user: viewer, account: account)
+      |> visit("/&#{group.character.username}")
+      |> wait_async()
+      |> refute_has("article", text: unrelated_marker)
+      |> refute_has("article", text: private_marker)
+      |> load_more_times(2)
+
+    assert_all_present(session, group_markers)
+    refute_has(session, "article", text: unrelated_marker)
+    refute_has(session, "article", text: private_marker)
+  end
+
+  test "profile feed load_more stays scoped to the profile author", %{
+    account: account,
+    viewer: viewer,
+    other_user: other_user
+  } do
+    limit = Bonfire.Common.Config.get(:default_pagination_limit, 2)
+    author = fake_user!()
+    profile_marker = "PROFILE_DEFERRED_#{System.unique_integer([:positive])}"
+    unrelated_marker = "PROFILE_UNRELATED_#{System.unique_integer([:positive])}"
+    private_marker = "PROFILE_PRIVATE_#{System.unique_integer([:positive])}"
+
+    profile_markers = create_public_noise(author, profile_marker, limit * 3)
+    create_public_noise(viewer, unrelated_marker, limit * 3)
+    create_private_noise(other_user, private_marker, limit * 12)
+
+    session =
+      conn(user: viewer, account: account)
+      |> visit("/@#{author.character.username}")
+      |> wait_async()
+      |> refute_has("article", text: unrelated_marker)
+      |> refute_has("article", text: private_marker)
+      |> load_more_times(2)
+
+    assert_all_present(session, profile_markers)
+    refute_has(session, "article", text: unrelated_marker)
+    refute_has(session, "article", text: private_marker)
+  end
+
+  test "hashtag feed load_more keeps the hashtag filter through deferred join windows", %{
+    account: account,
+    viewer: viewer,
+    other_user: other_user
+  } do
+    limit = Bonfire.Common.Config.get(:default_pagination_limit, 2)
+    tag = "ActualDeferred#{System.unique_integer([:positive])}"
+    tagged_marker = "HASHTAG_DEFERRED_#{System.unique_integer([:positive])}"
+    unrelated_marker = "HASHTAG_UNRELATED_#{System.unique_integer([:positive])}"
+    private_marker = "HASHTAG_PRIVATE_#{System.unique_integer([:positive])}"
+
+    tagged_markers =
+      for n <- 1..(limit * 3) do
+        marker = "#{tagged_marker}_#{n}_END"
+        publish(viewer, "public", "#{marker} ##{tag}")
+        marker
+      end
+
+    create_public_noise(viewer, unrelated_marker, limit * 3)
+    create_private_noise(other_user, private_marker, limit * 12)
+
+    session =
+      conn(user: viewer, account: account)
+      |> visit("/hashtag/#{tag}")
+      |> wait_async()
+      |> refute_has("article", text: unrelated_marker)
+      |> refute_has("article", text: private_marker)
+      |> load_more_times(2)
+
+    assert_all_present(session, tagged_markers)
+    refute_has(session, "article", text: unrelated_marker)
+    refute_has(session, "article", text: private_marker)
+  end
+
+  defp create_public_noise(user, marker_prefix, count) do
+    for n <- 1..count do
+      marker = "#{marker_prefix}_#{n}_END"
+      publish(user, "public", marker)
+      marker
+    end
+  end
+
+  defp create_private_noise(user, marker_prefix, count) do
+    for n <- 1..count do
+      marker = "#{marker_prefix}_#{n}_END"
+      publish(user, "mentions", marker)
+      marker
+    end
+  end
+
+  defp publish(user, boundary, body) do
+    assert {:ok, _post} =
+             Posts.publish(
+               current_user: user,
+               boundary: boundary,
+               post_attrs: %{post_content: %{html_body: "<p>#{body}</p>"}}
+             )
+  end
+
+  defp load_more_times(session, times) do
+    Enum.reduce(1..times, session, fn _, current_session ->
+      current_session
+      |> assert_has("[data-id=load_more]")
+      |> click_button("[data-id=load_more]", "Load more")
+      |> wait_async()
+    end)
+  end
+
+  defp assert_all_present(session, markers) do
+    Enum.each(markers, fn marker ->
+      assert_has(session, "article", text: marker)
+    end)
+
+    session
+  end
+end

--- a/test/views/pagination/feed_auto_pagination_short_feed_test.exs
+++ b/test/views/pagination/feed_auto_pagination_short_feed_test.exs
@@ -1,21 +1,4 @@
 defmodule Bonfire.UI.Social.Feeds.AutoPaginationShortFeedTest do
-  @moduledoc """
-  Direct regression test for the bug where a group/topic feed with too few
-  activities to fill the viewport would auto-trigger the "Show older
-  activities" LoadMore (via IntersectionObserver), which then misrouted
-  through `Bonfire.Social.Feeds.LiveHandler.handle_event("load_more",
-  %{"context" => feed_id}, ...)` and loaded ~10+ unrelated activities from
-  other feeds.
-
-  Fix: `feed_live.sface` now uses `dom_id_suffix="show_older"` instead of
-  `context="show_older"`, so the auto-triggered load_more no longer carries
-  a misleading `phx-value-context` and falls through to the proper
-  fallback handler that uses `feed_filters.feed_ids` from socket assigns.
-
-  This test mounts a short-feed scenario and asserts no foreign entries
-  bleed in even when infinite-scroll is enabled (the configuration that
-  makes the IntersectionObserver fire on mount).
-  """
   use Bonfire.UI.Social.ConnCase, async: false
   @moduletag :ui
 
@@ -45,16 +28,19 @@ defmodule Bonfire.UI.Social.Feeds.AutoPaginationShortFeedTest do
       account: account,
       me: me
     } do
-      # Enable doom-scroll so phx-scroll auto-fires load_more on mount.
       Settings.put([:ui, :infinite_scroll], true, current_user: me, scope: :user)
 
-      # A group with only 2 posts (far less than `default_pagination_limit`).
-      group = Simulate.fake_group!(me, %{name: "Tiny Group"})
+      group =
+        Simulate.fake_group!(me, %{
+          name: "Tiny Group",
+          membership: "local:members",
+          visibility: "nonfederated",
+          participation: "anyone"
+        })
+
       Simulate.fake_post_in_group!(me, group, "<p>tiny group post A</p>")
       Simulate.fake_post_in_group!(me, group, "<p>tiny group post B</p>")
 
-      # And many unrelated posts in the user's local feed: these would leak
-      # in if load_more falls through to the unfiltered explore branch.
       for n <- 1..15 do
         {:ok, _} =
           Posts.publish(
@@ -66,9 +52,6 @@ defmodule Bonfire.UI.Social.Feeds.AutoPaginationShortFeedTest do
 
       conn = conn(user: me, account: account)
 
-      # Regression: with doom-scroll on and only 2 entries, the "Show older"
-      # LoadMore's IntersectionObserver fires on mount and used to misroute
-      # through the context="show_older" stale clause, leaking foreign posts.
       conn
       |> visit("/&#{group.character.username}")
       |> wait_async()
@@ -83,7 +66,14 @@ defmodule Bonfire.UI.Social.Feeds.AutoPaginationShortFeedTest do
     } do
       Settings.put([:ui, :infinite_scroll], :preload, current_user: me, scope: :user)
 
-      group = Simulate.fake_group!(me, %{name: "Tiny Preload Group"})
+      group =
+        Simulate.fake_group!(me, %{
+          name: "Tiny Preload Group",
+          membership: "local:members",
+          visibility: "nonfederated",
+          participation: "anyone"
+        })
+
       Simulate.fake_post_in_group!(me, group, "<p>preload group post 1</p>")
       Simulate.fake_post_in_group!(me, group, "<p>preload group post 2</p>")
 
@@ -108,37 +98,15 @@ defmodule Bonfire.UI.Social.Feeds.AutoPaginationShortFeedTest do
   end
 
   describe "Show older activities LoadMore" do
-    test "does not carry phx-value-context (uses dom_id_suffix instead)", %{
-      account: account,
-      me: me
-    } do
-      # Span multiple days so the "Show older" LoadMore renders below the
-      # primary LoadMore. Reuse the existing fake_post helper.
-      alias Bonfire.Common.DatesTimes
-      import Bonfire.Posts.Fake, only: [fake_post!: 3]
+    test "uses dom_id_suffix rather than context" do
+      source =
+        __DIR__
+        |> Path.join("../../../lib/components/feeds/feed_live.sface")
+        |> Path.expand()
+        |> File.read!()
 
-      Settings.put([:ui, :infinite_scroll], true, current_user: me, scope: :user)
-
-      fake_post!(me, "public", %{
-        post_content: %{html_body: "<p>today</p>"},
-        id: DatesTimes.now() |> DatesTimes.generate_ulid()
-      })
-
-      for n <- 1..5 do
-        fake_post!(me, "public", %{
-          post_content: %{html_body: "<p>old #{n}</p>"},
-          id: DatesTimes.past(n + 2, :day) |> DatesTimes.generate_ulid()
-        })
-      end
-
-      conn(user: me, account: account)
-      |> visit("/feed/local?time_limit=1")
-      |> assert_has("#load_more_show_older[data-id=load_more]")
-      # Crucially: no `phx-value-context` attr on the show_older LoadMore.
-      # Phoenix omits the attr entirely when the bound expression is nil,
-      # so the stale `%{"context" => feed_id}` clause in the Feeds
-      # LiveHandler can no longer match.
-      |> refute_has(~s|#load_more_show_older[phx-value-context]|)
+      assert source =~ ~s|dom_id_suffix="show_older"|
+      refute source =~ ~s|context="show_older"|
     end
   end
 end

--- a/test/views/pagination/feed_backend_benchmark_target_test.exs
+++ b/test/views/pagination/feed_backend_benchmark_target_test.exs
@@ -1,0 +1,98 @@
+defmodule Bonfire.UI.Social.Feeds.FeedBackendBenchmarkTargetTest do
+  use Bonfire.UI.Social.ConnCase, async: false
+  @moduletag :ui
+
+  use Bonfire.Common.Config
+
+  alias Bonfire.Posts
+  alias Bonfire.Social.FeedActivities
+
+  setup do
+    original_deferred = Config.get([Bonfire.Social.Feeds, :query_with_deferred_join])
+    original_time_limit = Config.get([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+
+    Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], true)
+    repo().delete_all(Bonfire.Data.Social.FeedPublish)
+
+    on_exit(fn ->
+      Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], original_deferred)
+      Config.put([Bonfire.UI.Social.FeedLive, :time_limit], original_time_limit)
+    end)
+
+    %{viewer: fake_user!()}
+  end
+
+  test "feed_backend target uses the normal no-time-limit local feed path", %{viewer: viewer} do
+    with_pagination_hard_max_limit(500)
+
+    for n <- 1..3 do
+      assert {:ok, _post} =
+               Posts.publish(
+                 current_user: viewer,
+                 boundary: "public",
+                 post_attrs: %{post_content: %{html_body: "<p>benchmark target #{n}</p>"}}
+               )
+    end
+
+    assert %{edges: edges, page_info: page_info} = Bonfire.UI.Social.Benchmark.feed_full_backend()
+    assert length(edges) > 0
+    assert is_map(page_info)
+
+    query_string =
+      with_feed_time_limit(0, fn ->
+        FeedActivities.feed(:local, limit: 20, return: :query)
+      end)
+      |> Inspect.Ecto.Query.to_string()
+
+    assert query_string =~ " in subquery(from"
+    assert query_string =~ "f0.feed_id == ^\"3SERSFR0MY0VR10CA11NSTANCE\""
+    refute query_string =~ "is_nil(c5.id) or is_nil(p6.peer_id)"
+
+    assert %{rows: [[indexdef]]} =
+             repo().query!(
+               """
+               select indexdef
+               from pg_indexes
+               where tablename = $1 and indexname = $2
+               """,
+               [
+                 "bonfire_data_social_feed_publish",
+                 "bonfire_data_social_feed_publish_feed_id_id_idx"
+               ]
+             )
+
+    assert indexdef =~ "(feed_id, id)"
+
+    without_boundaries_string =
+      with_feed_time_limit(0, fn ->
+        FeedActivities.feed(:local, limit: 20, return: :query, skip_boundary_check: true)
+      end)
+      |> Inspect.Ecto.Query.to_string()
+
+    assert query_string != without_boundaries_string
+  end
+
+  defp with_feed_time_limit(days, fun) do
+    previous = Config.get([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+    Config.put([Bonfire.UI.Social.FeedLive, :time_limit], days)
+
+    try do
+      fun.()
+    after
+      Config.put([Bonfire.UI.Social.FeedLive, :time_limit], previous)
+    end
+  end
+
+  defp with_pagination_hard_max_limit(limit) do
+    key = [:bonfire, :pagination_hard_max_limit]
+    previous = Process.get(key)
+
+    Process.put(key, limit)
+
+    on_exit(fn ->
+      if is_nil(previous),
+        do: Process.delete(key),
+        else: Process.put(key, previous)
+    end)
+  end
+end

--- a/test/views/pagination/feed_browser_js_time_limit_test.exs
+++ b/test/views/pagination/feed_browser_js_time_limit_test.exs
@@ -1,0 +1,161 @@
+defmodule Bonfire.UI.Social.Feeds.FeedBrowserJSTimeLimitTest do
+  use Bonfire.UI.Social.ConnCase, async: false
+  @moduletag :ui
+  @moduletag :browser_js
+  @moduletag db_sandbox: false
+
+  use Bonfire.Common.Config
+
+  import Bonfire.Posts.Fake, except: [fake_remote_user!: 0]
+
+  alias Bonfire.Common.DatesTimes
+
+  @playwright_timeout 120_000
+
+  setup do
+    original_deferred = Config.get([Bonfire.Social.Feeds, :query_with_deferred_join])
+    original_default_limit = Config.get(:default_pagination_limit)
+
+    Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], false)
+    Config.put(:default_pagination_limit, 2)
+    Bonfire.Common.Cache.remove_all()
+
+    account = fake_account!()
+    _viewer = fake_user!(account)
+    author = fake_user!()
+
+    repo().delete_all(Bonfire.Data.Social.FeedPublish)
+
+    dated_post!(author, "browser recent post", "Browser recent", DatesTimes.past(1, :hour))
+    dated_post!(author, "browser two days", "Browser two days", DatesTimes.past(2, :day))
+    dated_post!(author, "browser three days", "Browser three days", DatesTimes.past(3, :day))
+    dated_post!(author, "browser week old", "Browser week old", DatesTimes.past(7, :day))
+    dated_post!(author, "browser month old", "Browser month old", DatesTimes.past(30, :day))
+    dated_post!(author, "browser old", "Browser old", DatesTimes.past(60, :day))
+
+    on_exit(fn ->
+      Bonfire.Common.Cache.remove_all()
+      Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], original_deferred)
+      Config.put(:default_pagination_limit, original_default_limit)
+    end)
+
+    :ok
+  end
+
+  @tag :browser_js
+  test "guest browser JS can remove local feed time limits and continue paginating with cache bypassed" do
+    run_browser_time_limit_flow("#{Bonfire.Web.Endpoint.url()}/feed/?cache=skip&time_limit=1")
+  end
+
+  @tag :browser_js
+  test "guest browser JS keeps cached time-limited and all-time pages separate" do
+    run_browser_time_limit_flow("#{Bonfire.Web.Endpoint.url()}/feed/?time_limit=1")
+  end
+
+  defp run_browser_time_limit_flow(url) do
+    assert Application.get_env(:bonfire, Bonfire.Web.Endpoint)[:server],
+           "Run this test through test-pagination-regression.sh ui-browser-js so PHX_SERVER=yes starts the endpoint."
+
+    assert System.find_executable("npx"),
+           "npx is required for the real browser JS regression target."
+
+    script = browser_script(url)
+
+    {output, status} =
+      System.cmd(
+        "npx",
+        [
+          "--yes",
+          "-p",
+          "playwright",
+          "-c",
+          "PW_BIN=$(which playwright); export NODE_PATH=$(dirname $(dirname $PW_BIN)); node -e #{shell_quote(script)}"
+        ],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+    assert output =~ "browser_js_time_limit"
+  end
+
+  defp dated_post!(user, summary, body, date) do
+    fake_post!(user, "public", %{
+      post_content: %{
+        summary: summary,
+        html_body: "<p>#{body}</p>"
+      },
+      id: DatesTimes.generate_ulid(date)
+    })
+  end
+
+  defp browser_script(url) do
+    """
+    const { chromium } = require("playwright");
+
+    (async () => {
+      const browser = await chromium.launch({ headless: true });
+      const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+      const errors = [];
+      page.on("console", message => {
+        if (message.type() === "error") errors.push(message.text());
+      });
+      page.on("pageerror", error => errors.push(error.message));
+
+      await page.goto(#{Jason.encode!(url)}, { waitUntil: "domcontentloaded", timeout: #{@playwright_timeout} });
+      await page.waitForSelector("[data-id=feed] article", { timeout: #{@playwright_timeout} });
+
+      const articles = page.locator("[data-id=feed] article");
+      const initialCount = await articles.count();
+      if (initialCount !== 1) {
+        throw new Error(`expected one time-limited article, got ${initialCount}`);
+      }
+
+      const loadAll = page.locator("[data-id=load_all_time]").first();
+      await loadAll.waitFor({ state: "visible", timeout: #{@playwright_timeout} });
+      await Promise.all([
+        page.waitForURL(url => url.searchParams.get("time_limit") === "0", { timeout: #{@playwright_timeout} }),
+        loadAll.click()
+      ]);
+      await page.waitForSelector("[data-id=feed] article", { timeout: #{@playwright_timeout} });
+
+      const afterLoadAllCount = await articles.count();
+      if (afterLoadAllCount < 2) {
+        throw new Error(`expected older activities after removing time_limit, got ${afterLoadAllCount}`);
+      }
+
+      const nextPage = page.locator("a[data-id=next_page]").first();
+      await nextPage.waitFor({ state: "visible", timeout: #{@playwright_timeout} });
+      await Promise.all([
+        page.waitForURL(url => url.searchParams.has("after") || url.toString().includes("%5Bafter%5D"), { timeout: #{@playwright_timeout} }),
+        nextPage.click()
+      ]);
+      await page.waitForSelector("[data-id=feed] article", { timeout: #{@playwright_timeout} });
+
+      const afterNextPageCount = await articles.count();
+      if (afterNextPageCount < 1) {
+        throw new Error("expected at least one activity after following the next_page link");
+      }
+      if (errors.length > 0) {
+        throw new Error(`browser JS errors: ${errors.join(" | ")}`);
+      }
+
+      console.log(JSON.stringify({
+        test: "browser_js_time_limit",
+        initialCount,
+        afterLoadAllCount,
+        afterNextPageCount,
+        url: page.url()
+      }));
+
+      await browser.close();
+    })().catch(error => {
+      console.error(error.stack || error.message);
+      process.exit(1);
+    });
+    """
+  end
+
+  defp shell_quote(value) do
+    "'" <> String.replace(value, "'", "'\"'\"'") <> "'"
+  end
+end

--- a/test/views/pagination/feed_full_preload_render_stress_test.exs
+++ b/test/views/pagination/feed_full_preload_render_stress_test.exs
@@ -1,0 +1,335 @@
+defmodule Bonfire.UI.Social.Feeds.FeedFullPreloadRenderStressTest do
+  use Bonfire.UI.Social.ConnCase, async: false
+  @moduletag :ui
+
+  use Bonfire.Common.Config
+
+  import Bonfire.Posts.Fake
+
+  alias Bonfire.Data.Social.FeedPublish
+  alias Bonfire.UI.Social.Benchmark
+  alias Bonfire.Social.FeedActivities
+
+  @default_page_limit 20
+  @default_hidden_multiplier 32
+  @default_hidden_extra_rows 5
+  @default_preload_max_ms 1_000
+  @default_component_render_max_ms 3_000
+  @default_initial_render_max_ms 5_000
+  @default_load_more_render_max_ms 3_000
+
+  setup do
+    page_limit = env_integer("BONFIRE_FULL_RENDER_PAGE_LIMIT", @default_page_limit)
+
+    hidden_multiplier =
+      env_integer("BONFIRE_FULL_RENDER_HIDDEN_MULTIPLIER", @default_hidden_multiplier)
+
+    hidden_extra_rows =
+      env_integer("BONFIRE_FULL_RENDER_HIDDEN_EXTRA_ROWS", @default_hidden_extra_rows)
+
+    account = fake_account!()
+    viewer = fake_user!(account)
+    hidden_author = fake_user!()
+
+    original_deferred = Config.get([Bonfire.Social.Feeds, :query_with_deferred_join])
+    original_time_limit = Config.get([Bonfire.UI.Social.FeedLive, :time_limit], 7)
+    original_default_limit = Config.get(:default_pagination_limit)
+    original_hard_max = Config.get(:pagination_hard_max_limit)
+
+    Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], true)
+    Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
+    Config.put(:default_pagination_limit, page_limit)
+    Config.put(:pagination_hard_max_limit, max(original_hard_max || 0, page_limit))
+
+    repo().delete_all(Bonfire.Data.Social.FeedPublish)
+
+    fallback_handler_id = {__MODULE__, self(), make_ref()}
+
+    :telemetry.attach(
+      fallback_handler_id,
+      [:bonfire, :social, :feed_loader, :deferred_join, :fallback],
+      fn _event, _measurements, metadata, test_pid ->
+        send(test_pid, {:deferred_join_fallback, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn ->
+      :telemetry.detach(fallback_handler_id)
+      Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], original_deferred)
+      Config.put([Bonfire.UI.Social.FeedLive, :time_limit], original_time_limit)
+      Config.put(:default_pagination_limit, original_default_limit)
+      Config.put(:pagination_hard_max_limit, original_hard_max)
+    end)
+
+    %{
+      account: account,
+      viewer: viewer,
+      hidden_author: hidden_author,
+      page_limit: page_limit,
+      hidden_count: page_limit * hidden_multiplier + hidden_extra_rows
+    }
+  end
+
+  @tag timeout: 600_000
+  test "full preload backend and rendered load_more recover a 20-item local page after hidden local rows without fallback",
+       %{
+         account: account,
+         viewer: viewer,
+         hidden_author: hidden_author,
+         page_limit: page_limit,
+         hidden_count: hidden_count
+       } do
+    tag = System.unique_integer([:positive])
+    older_prefix = "FULL_RENDER_OLDER_#{tag}"
+    hidden_prefix = "FULL_RENDER_HIDDEN_#{tag}"
+    newer_prefix = "FULL_RENDER_NEWER_#{tag}"
+
+    {older_posts, older_markers} = create_posts(viewer, "public", older_prefix, page_limit)
+
+    {hidden_posts, _hidden_markers} =
+      create_posts(hidden_author, "mentions", hidden_prefix, hidden_count)
+
+    Enum.each(hidden_posts, &publish_to_local_feed/1)
+
+    {newer_posts, newer_markers} = create_posts(viewer, "public", newer_prefix, page_limit)
+
+    {first_preload_us, first_page} =
+      :timer.tc(fn ->
+        full_preload_feed(viewer, page_limit)
+      end)
+
+    assert %{edges: first_edges, page_info: %{end_cursor: cursor}} = first_page
+    assert length(first_edges) == page_limit
+    assert is_binary(cursor)
+
+    assert_page_contains_all(first_edges, newer_posts)
+    refute_page_contains_any(first_edges, hidden_posts)
+
+    hidden_window =
+      FeedActivities.feed(:local,
+        current_user: viewer,
+        after: cursor,
+        limit: page_limit,
+        skip_boundary_check: true,
+        show_objects_only_once: false,
+        preload: false
+      )
+
+    assert_page_contains_any(hidden_window.edges, hidden_posts)
+
+    {second_preload_us, second_page} =
+      :timer.tc(fn ->
+        full_preload_feed(viewer, page_limit, after: cursor)
+      end)
+
+    assert %{edges: second_edges} = second_page
+    assert length(second_edges) == page_limit
+    assert_page_contains_all(second_edges, older_posts)
+    refute_page_contains_any(second_edges, hidden_posts)
+    assert_disjoint_pages(first_edges, second_edges)
+
+    {component_render_us, component_html} =
+      :timer.tc(fn ->
+        Benchmark.render_feed(first_page,
+          current_user: viewer,
+          feed_name: :local,
+          feed_id: :local,
+          feed_filters: %{feed_name: :local},
+          live_update_many_preload_mode: :inline,
+          feed_live_update_many_preload_mode: :inline,
+          hide_filters: true
+        )
+      end)
+
+    assert_all_activity_ids_present(component_html, newer_posts)
+    refute_activity_ids_present(component_html, hidden_posts)
+
+    first_preload_ms = us_to_ms(first_preload_us)
+    second_preload_ms = us_to_ms(second_preload_us)
+    component_render_ms = us_to_ms(component_render_us)
+
+    assert_under_ms(
+      "full preload backend",
+      max(first_preload_ms, second_preload_ms),
+      "BONFIRE_FULL_PRELOAD_MAX_MS",
+      @default_preload_max_ms
+    )
+
+    assert_under_ms(
+      "full preload component render",
+      component_render_ms,
+      "BONFIRE_FULL_COMPONENT_RENDER_MAX_MS",
+      @default_component_render_max_ms
+    )
+
+    {initial_render_us, session} =
+      :timer.tc(fn ->
+        conn(user: viewer, account: account)
+        |> visit("/feed/local?cache=skip&time_limit=0")
+        |> wait_async()
+      end)
+
+    initial_render_ms = us_to_ms(initial_render_us)
+
+    session =
+      session
+      |> assert_has("[data-id=feed] article", count: page_limit)
+      |> assert_all_articles_present(newer_markers)
+      |> refute_has("article", text: hidden_prefix)
+      |> assert_has("[data-id=load_more]")
+
+    assert_under_ms(
+      "initial full render",
+      initial_render_ms,
+      "BONFIRE_FULL_INITIAL_RENDER_MAX_MS",
+      @default_initial_render_max_ms
+    )
+
+    {load_more_render_us, session} =
+      :timer.tc(fn ->
+        session
+        |> click_button("[data-id=load_more]", "Load more")
+        |> wait_async()
+      end)
+
+    load_more_render_ms = us_to_ms(load_more_render_us)
+
+    session
+    |> assert_has("[data-id=feed] article", count: page_limit * 2)
+    |> assert_all_articles_present(older_markers)
+    |> assert_all_articles_present(newer_markers)
+    |> refute_has("article", text: hidden_prefix)
+
+    assert_under_ms(
+      "load_more full render",
+      load_more_render_ms,
+      "BONFIRE_FULL_LOAD_MORE_RENDER_MAX_MS",
+      @default_load_more_render_max_ms
+    )
+
+    refute_received {:deferred_join_fallback, metadata},
+                    "Expected full preload/render stress not to use non-deferred fallback, got #{inspect(metadata)}"
+
+    IO.puts(
+      "full_preload_render_stress page_limit=#{page_limit} hidden_rows=#{hidden_count} first_preload_ms=#{first_preload_ms} second_preload_ms=#{second_preload_ms} component_render_ms=#{component_render_ms} initial_render_ms=#{initial_render_ms} load_more_render_ms=#{load_more_render_ms}"
+    )
+  end
+
+  defp full_preload_feed(viewer, page_limit, opts \\ []) do
+    FeedActivities.feed(
+      :local,
+      Keyword.merge(
+        [
+          current_user: viewer,
+          limit: page_limit,
+          preload: :feed,
+          show_objects_only_once: false
+        ],
+        opts
+      )
+    )
+  end
+
+  defp create_posts(user, boundary, marker_prefix, count) do
+    posts_and_markers =
+      for n <- 1..count do
+        marker = "#{marker_prefix}_#{n}_END"
+
+        post =
+          fake_post!(user, boundary, %{
+            post_content: %{
+              name: marker,
+              html_body: marker
+            }
+          })
+
+        {post, marker}
+      end
+
+    Enum.unzip(posts_and_markers)
+  end
+
+  defp publish_to_local_feed(post) do
+    assert {:ok, _published} =
+             repo().upsert(
+               Ecto.Changeset.cast(
+                 %FeedPublish{},
+                 %{feed_id: local_feed_id(), id: post.id},
+                 [:feed_id, :id]
+               )
+             )
+  end
+
+  defp local_feed_id,
+    do: Bonfire.Boundaries.Circles.get_id(:local) || "3SERSFR0MY0VR10CA11NSTANCE"
+
+  defp assert_all_articles_present(session, markers) do
+    Enum.each(markers, fn marker ->
+      assert_has(session, "article", text: marker)
+    end)
+
+    session
+  end
+
+  defp assert_all_activity_ids_present(html, posts) do
+    Enum.each(posts, fn post ->
+      assert html =~ post.id
+    end)
+  end
+
+  defp refute_activity_ids_present(html, posts) do
+    Enum.each(posts, fn post ->
+      refute html =~ post.id
+    end)
+  end
+
+  defp assert_disjoint_pages(first_edges, second_edges) do
+    overlap = MapSet.intersection(activity_ids(first_edges), activity_ids(second_edges))
+
+    assert MapSet.size(overlap) == 0,
+           "Expected full preload pages not to overlap, got #{inspect(MapSet.to_list(overlap))}"
+  end
+
+  defp activity_ids(edges), do: MapSet.new(Enum.map(edges, & &1.activity.id))
+
+  defp post_ids(posts), do: MapSet.new(Enum.map(posts, & &1.id))
+
+  defp assert_page_contains_all(edges, posts) do
+    missing = MapSet.difference(post_ids(posts), activity_ids(edges))
+
+    assert MapSet.size(missing) == 0,
+           "Expected page to contain posts #{inspect(MapSet.to_list(missing))}"
+  end
+
+  defp assert_page_contains_any(edges, posts) do
+    overlap = MapSet.intersection(post_ids(posts), activity_ids(edges))
+
+    assert MapSet.size(overlap) > 0,
+           "Expected page to contain at least one of #{MapSet.size(post_ids(posts))} posts"
+  end
+
+  defp refute_page_contains_any(edges, posts) do
+    overlap = MapSet.intersection(post_ids(posts), activity_ids(edges))
+
+    assert MapSet.size(overlap) == 0,
+           "Expected page not to contain hidden posts #{inspect(MapSet.to_list(overlap))}"
+  end
+
+  defp assert_under_ms(label, actual_ms, env_name, default_ms) do
+    max_ms = env_integer(env_name, default_ms)
+
+    assert actual_ms <= max_ms,
+           "#{label} took #{actual_ms}ms, above #{env_name}=#{max_ms}ms"
+  end
+
+  defp us_to_ms(us), do: Float.round(us / 1_000, 2)
+
+  defp env_integer(name, default) do
+    case System.get_env(name) do
+      nil -> default
+      "" -> default
+      value -> String.to_integer(value)
+    end
+  end
+end

--- a/test/views/pagination/feed_load_more_remove_time_filter_test.exs
+++ b/test/views/pagination/feed_load_more_remove_time_filter_test.exs
@@ -1,17 +1,20 @@
 defmodule Bonfire.UI.Social.Feeds.LoadMoreRemoveTimeFilterTest do
   use Bonfire.UI.Social.ConnCase, async: false
   @moduletag :ui
-  import Bonfire.Common.Simulation
   use Bonfire.Common.Config
-  alias Bonfire.Social.Fake
-  alias Bonfire.Social.Boosts
-  alias Bonfire.Social.Likes
-  alias Bonfire.Social.Graph.Follows
-  alias Bonfire.Posts
   import Bonfire.Posts.Fake, except: [fake_remote_user!: 0]
   use Mneme
-  import Untangle
   alias Bonfire.Common.DatesTimes
+
+  defp dated_post!(user, summary, body, date) do
+    fake_post!(user, "public", %{
+      post_content: %{
+        summary: summary,
+        html_body: "<p>#{body}</p>"
+      },
+      id: DatesTimes.generate_ulid(date)
+    })
+  end
 
   describe "Load All Time Buttons in Feeds" do
     setup do
@@ -21,13 +24,15 @@ defmodule Bonfire.UI.Social.Feeds.LoadMoreRemoveTimeFilterTest do
       # Set the test configuration (disabling deferred joins because they affect pagination)
       Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], false)
       # Process.put([:bonfire, :default_pagination_limit], limit)
-
-      # Make sure we start with a blank slate
-      repo().delete_all(Bonfire.Data.Social.FeedPublish)
+      Bonfire.Common.Cache.remove_all()
 
       # Create test users
       account = fake_account!()
       alice = fake_user!(account)
+      author = fake_user!()
+
+      # Make sure user/account setup activities do not affect feed counts.
+      repo().delete_all(Bonfire.Data.Social.FeedPublish)
 
       # Create posts with specific dates
       limit = Bonfire.Common.Config.get(:default_pagination_limit, 2)
@@ -35,68 +40,27 @@ defmodule Bonfire.UI.Social.Feeds.LoadMoreRemoveTimeFilterTest do
 
       ## Create posts with systematically varied dates for all tests
 
-      # Today's post
       today_post =
-        fake_post!(alice, "public", %{
-          post_content: %{
-            summary: "today's post",
-            html_body: "<p>Today's post content</p>"
-          },
-          id: DatesTimes.now() |> DatesTimes.generate_ulid()
-        })
+        dated_post!(author, "today's post", "Today's post content", DatesTimes.past(1, :hour))
 
-      # Yesterday's post
       two_days_ago_post =
-        fake_post!(alice, "public", %{
-          post_content: %{
-            summary: "2 days ago post",
-            html_body: "<p>Yesterday's content</p>"
-          },
-          id: DatesTimes.past(2, :day) |> DatesTimes.generate_ulid()
-        })
+        dated_post!(author, "2 days ago post", "Yesterday's content", DatesTimes.past(2, :day))
 
-      # Three days ago post
       three_days_ago_post =
-        fake_post!(alice, "public", %{
-          post_content: %{
-            summary: "3 days ago post",
-            html_body: "<p>Three days ago content</p>"
-          },
-          id: DatesTimes.past(3, :day) |> DatesTimes.generate_ulid()
-        })
+        dated_post!(author, "3 days ago post", "Three days ago content", DatesTimes.past(3, :day))
 
-      # Week old post
       week_old_post =
-        fake_post!(alice, "public", %{
-          post_content: %{
-            summary: "Week old post",
-            html_body: "<p>Week-old content</p>"
-          },
-          id: DatesTimes.past(7, :day) |> DatesTimes.generate_ulid()
-        })
+        dated_post!(author, "Week old post", "Week-old content", DatesTimes.past(7, :day))
 
-      # Month old post
       month_old_post =
-        fake_post!(alice, "public", %{
-          post_content: %{
-            summary: "Month old post",
-            html_body: "<p>Month-old content</p>"
-          },
-          id: DatesTimes.past(30, :day) |> DatesTimes.generate_ulid()
-        })
+        dated_post!(author, "Month old post", "Month-old content", DatesTimes.past(30, :day))
 
-      # Old post (60 days ago)
       old_post =
-        fake_post!(alice, "public", %{
-          post_content: %{
-            summary: "Old post",
-            html_body: "<p>Post from 60 days ago</p>"
-          },
-          id: DatesTimes.past(60, :day) |> DatesTimes.generate_ulid()
-        })
+        dated_post!(author, "Old post", "Post from 60 days ago", DatesTimes.past(60, :day))
 
       # Return the original config to be used in on_exit
       on_exit(fn ->
+        Bonfire.Common.Cache.remove_all()
         Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], original_config)
       end)
 
@@ -115,19 +79,42 @@ defmodule Bonfire.UI.Social.Feeds.LoadMoreRemoveTimeFilterTest do
       }
     end
 
-    @tag :skip
-    # FIXME: after "Show older activities" drops `time_limit`, subsequent
-    # "Load more" clicks don't persist the override, so the page stops
-    # paginating after 1 + limit. Tracked separately from the show_older
-    # context→feed_id misrouting (fixed: load_more no longer pulls from
-    # other feeds).
+    @tag :pagination_time_limit
+    test "cached local feed pages do not reuse a different time limit", %{
+      alice: alice,
+      account: account,
+      total_posts: total_posts
+    } do
+      opts = [
+        current_user: alice,
+        current_account: account,
+        cache: true,
+        limit: total_posts,
+        preload: false,
+        query_with_deferred_join: false,
+        show_objects_only_once: false
+      ]
+
+      limited_feed = Bonfire.Social.FeedLoader.feed(:local, %{time_limit: 1}, opts)
+      all_time_feed = Bonfire.Social.FeedLoader.feed(:local, %{time_limit: 0}, opts)
+
+      assert length(limited_feed.edges) == 1
+      assert length(all_time_feed.edges) == total_posts
+    end
+
+    @tag :pagination_time_limit
     test "As a logged-in user, when I click the load_all_time button with date sorting, it should remove time limit and load more activities",
-         %{alice: alice, account: account, total_posts: total_posts, limit: limit} do
+         %{
+           alice: alice,
+           account: account,
+           total_posts: total_posts,
+           limit: limit
+         } do
       conn = conn(user: alice, account: account)
 
-      # Visit feed with time_limit=1 via URL param (the time range control is now inside the Filters modal, so URL param is a more stable way to set it in tests)
+      # Fake posts do not exercise the production cache invalidation path, so bypass feed cache.
       conn
-      |> visit("/feed/local?time_limit=1")
+      |> visit("/feed/local?cache=skip&time_limit=1")
       |> assert_has_or_open_browser("[data-id=feed] article [data-id=object_body]")
       # Check that we only see posts from today (count should be less than total)
       # Today's post
@@ -159,17 +146,15 @@ defmodule Bonfire.UI.Social.Feeds.LoadMoreRemoveTimeFilterTest do
       )
     end
 
+    @tag :pagination_time_limit
     test "As a logged-in user, when I click the load_all_time button with non-date sorting, it should reload the feed with no time limit",
          %{alice: alice, account: account, total_posts: total_posts, limit: limit} do
       conn = conn(user: alice, account: account)
 
-      # Visit feed with time_limit=1 via URL param (the time range control is now inside the Filters modal, so URL param is a more stable way to set it in tests)
+      # Fake posts do not exercise the production cache invalidation path, so bypass feed cache.
       conn
-      |> visit("/feed/local?time_limit=1")
+      |> visit("/feed/local?cache=skip&time_limit=1&sort_by=like_count&sort_order=desc")
       |> assert_has_or_open_browser("[data-id=feed] article")
-      # Set sort to likes via the inline sort dropdown (still rendered on the page)
-      |> click_button("#order_dropdown_feed button[phx-value-sort_by='like_count']", "Most liked")
-      |> wait_async()
       # Check that we only see posts from today (count should be less than total)
       # Today's post
       |> assert_has("[data-id=feed] article [data-id=object_body]", count: 1)
@@ -193,14 +178,15 @@ defmodule Bonfire.UI.Social.Feeds.LoadMoreRemoveTimeFilterTest do
       |> assert_has("[data-id=feed] article [data-id=object_body]", count: total_posts)
     end
 
+    @tag :pagination_time_limit
     test "As a guest user with no socket, I can use the load_all_time link to remove time limits",
-         %{total_posts: total_posts, limit: limit} do
+         %{limit: limit} do
       # Use a guest connection (no user)
       conn = conn()
 
       # Visit feed with a time_limit of 1 day
       conn
-      |> visit("/feed/?time_limit=1")
+      |> visit("/feed/?cache=skip&time_limit=1")
       # Check that we only see posts from today
       |> assert_has_or_open_browser("[data-id=feed] article [data-id=object_body]", count: 1)
       # Cannot use "seconds ago" in test as depends on the time of the test run can change to "now", but this is not meaningful for the test.

--- a/test/views/pagination/load_more_context_attr_test.exs
+++ b/test/views/pagination/load_more_context_attr_test.exs
@@ -1,33 +1,4 @@
 defmodule Bonfire.UI.Social.Feeds.LoadMoreContextAttrTest do
-  @moduledoc """
-  Regression tests for the `phx-value-context` attribute on LoadMoreLive
-  when fired into `Bonfire.Social.Feeds.LiveHandler`.
-
-  The 2023 `%{"context" => feed_id}` clause in
-  `feeds_live_handler.ex:42` was written when `context` was expected to
-  be a real feed UID. Over time, call sites began using `context` as a
-  UI label (tab name, `"show_older"`, etc.). When a LoadMoreLive with a
-  label-style `context` triggers in the Feeds handler, the stale clause
-  misroutes the request: the label is passed as `feed_name` to
-  `FeedLoader.feed/3`, clobbers `feed_filters.feed_name`, and falls
-  through to an unfiltered query in `feed_query/3` (since
-  `Types.uid_or_uids("show_older")` returns nil).
-
-  The user-visible bug: a group feed page showing 3 entries auto-triggered
-  the "Show older activities" LoadMore (because the 3 items did not fill
-  the viewport), the load_more event arrived with
-  `context: "show_older"`, and the unfiltered query returned ~12
-  unrelated activities from other groups.
-
-  Fix: the "Show older" LoadMore in `feed_live.sface` now uses
-  `dom_id_suffix="show_older"` instead of `context="show_older"`, so no
-  `phx-value-context` is sent and the fallback handler (which uses
-  `feed_filters` from socket assigns) runs correctly.
-
-  These tests guard against the stale 2023 clause re-introducing the bug
-  if another non-UID `context` value ever leaks into a Feeds load_more
-  event.
-  """
   use Bonfire.UI.Social.ConnCase, async: false
   @moduletag :ui
 
@@ -56,14 +27,17 @@ defmodule Bonfire.UI.Social.Feeds.LoadMoreContextAttrTest do
       account: account,
       me: me
     } do
-      # Group with only 2 of its own posts.
-      group = Simulate.fake_group!(me, %{name: "Scope Group"})
+      group =
+        Simulate.fake_group!(me, %{
+          name: "Scope Group",
+          membership: "local:members",
+          visibility: "nonfederated",
+          participation: "anyone"
+        })
+
       Simulate.fake_post_in_group!(me, group, "<p>group post 1</p>")
       Simulate.fake_post_in_group!(me, group, "<p>group post 2</p>")
 
-      # Many unrelated posts in the user's local feed; these would be
-      # returned by the unfiltered fallback query if load_more were ever
-      # misrouted again.
       for n <- 1..10 do
         {:ok, _} =
           Posts.publish(
@@ -73,15 +47,12 @@ defmodule Bonfire.UI.Social.Feeds.LoadMoreContextAttrTest do
           )
       end
 
-      # Regression: group feed must not leak unrelated activities even when
-      # the "Show older" LoadMore auto-triggers (the original bug surfaced
-      # via context="show_older" misrouting through the 2023 stale clause).
       conn(user: me, account: account)
       |> visit("/&#{group.character.username}")
       |> wait_async()
-      |> assert_has_or_open_browser("article", text: "group post 1")
+      |> assert_has("article", text: "group post 1")
       |> assert_has("article", text: "group post 2")
-      |> refute_has_or_open_browser("article", text: "unrelated")
+      |> refute_has("article", text: "unrelated")
     end
   end
 

--- a/test/views/pagination/load_more_with_deferred_join.exs
+++ b/test/views/pagination/load_more_with_deferred_join.exs
@@ -1,12 +1,9 @@
 defmodule Bonfire.UI.Social.Feeds.DeferredJoinPaginationTest do
   use Bonfire.UI.Social.ConnCase, async: false
   @moduletag :ui
-  import Bonfire.Common.Simulation
   use Bonfire.Common.Config
-  alias Bonfire.Social.Fake
   alias Bonfire.Posts
   use Mneme
-  import Untangle
 
   describe "Feed Pagination with Deferred Join" do
     setup do
@@ -61,9 +58,9 @@ defmodule Bonfire.UI.Social.Feeds.DeferredJoinPaginationTest do
                  )
       end
 
-      # Create (more recent) posts that would appear in the first window but won't be included by boundaries
-      # These should NOT appear in our feed due to boundary restrictions
-      for i <- 1..(limit * 8) do
+      # Create enough newer private posts to hide multiple deferred-join windows.
+      # The second load-more must still recover the older public posts without showing hidden content.
+      for i <- 1..(limit * 20) do
         Posts.publish(
           current_user: other_user,
           boundary: "mentions",


### PR DESCRIPTION
## Summary

Part 4 of the Bonfire feed query performance stack for bonfire-networks/bounties#1.

This extends UI-side regression coverage for local feed pagination:

- Add real browser JS coverage for time-limit and load-more behavior.
- Add full preload/render stress coverage.
- Keep cached local feed pages from reusing the wrong time-limit state.
- Avoid unnecessary canonical URL preload work in the flag action path.

## Stack

1. bonfire_common: https://github.com/bonfire-networks/bonfire_common/pull/15
2. bonfire_data_social: https://github.com/bonfire-networks/bonfire_data_social/pull/5
3. bonfire_social: https://github.com/bonfire-networks/bonfire_social/pull/7
4. bonfire_ui_social: https://github.com/bonfire-networks/bonfire_ui_social/pull/9
5. bonfire-app: https://github.com/bonfire-networks/bonfire-app/pull/1994

## Why

The bounty target is a backend feed query, but the change still needs to survive the user-facing load-more and render paths. These tests cover the browser and preload/render cases that can hide regressions not visible in a query-only benchmark.

## Validation

Stack-level validation was run from `bonfire-app` after applying the sibling branches:

```bash
BONFIRE_FULL_RENDER_HIDDEN_MULTIPLIER=128 BONFIRE_FULL_RENDER_HIDDEN_EXTRA_ROWS=25 ./test-pagination-regression.sh all-with-strict-benchmark
```

Relevant local results:

- Browser JS block: `2 tests, 0 failures`.
- Full preload/render stress:
  - `page_limit=20`
  - `hidden_rows=2585`
  - `first_preload_ms=194.47`
  - `second_preload_ms=164.74`
  - `initial_render_ms=977.3`
  - `load_more_render_ms=550.31`
- Other UI regression blocks passed in the same strict gate.

Additional local check:

- `git diff --check origin/main..HEAD`

## Known Limits

I do not have the campground database or maintainer hardware, so I am not claiming the official `feed_backend` benchmark has passed. That still needs maintainer verification on campground.
