### PR TITLE
Cache feed load-more render settings

### DIFF
--- a/lib/components/feeds/feed_live.ex
+++ b/lib/components/feeds/feed_live.ex
@@ -34,6 +34,8 @@ defmodule Bonfire.UI.Social.FeedLive do
   prop enable_marker, :boolean, default: false
   # 48 hours in ms
   prop markers_ttl, :integer, default: 172_800_000
+  prop query_with_deferred_join, :boolean, default: true
+  prop infinite_scroll, :any, default: :preload
 
   prop verb_default, :string, default: nil
 
@@ -426,7 +428,19 @@ defmodule Bonfire.UI.Social.FeedLive do
             ) && "until_hovered"),
        hide_activities:
          assigns(socket)[:hide_activities] ||
-           assigns(socket)[:__context__][:current_params]["hide_activities"]
+           assigns(socket)[:__context__][:current_params]["hide_activities"],
+       query_with_deferred_join:
+         Config.get([Bonfire.Social.Feeds, :query_with_deferred_join], true,
+           name: l("Use Deferred Joins"),
+           description: l("Technical setting for query performance optimization.")
+         ),
+       infinite_scroll:
+         Settings.get([:ui, :infinite_scroll], :preload,
+           context: assigns(socket)[:__context__],
+           name: l("Infinite Scrolling"),
+           description:
+             l("Enable infinite scrolling in feeds, or choose a hybrid approach.")
+         )
      )}
   end
 

--- a/lib/components/feeds/feed_live.sface
+++ b/lib/components/feeds/feed_live.sface
@@ -156,17 +156,10 @@
             {#match previous_end_cursor}
               {#case LoadMoreLive.final_cursor(@page_info) || LoadMoreLive.final_cursor(@previous_page_info)}
                 {#match final_end_cursor}
-                  {#case (Config.get([Bonfire.Social.Feeds, :query_with_deferred_join], true,
-                       name: l("Use Deferred Joins"),
-                       description: l("Technical setting for query performance optimization.")
-                     ) &&
+                  {#case (@query_with_deferred_join &&
                        !@deferred_join_multiply_limit) or @deferred_join_multiply_limit < 4}
                     {#match query_with_deferred_join?}
-                      {#case Settings.get([:ui, :infinite_scroll], :preload,
-                          context: @__context__,
-                          name: l("Infinite Scrolling"),
-                          description: l("Enable infinite scrolling in feeds, or choose a hybrid approach.")
-                        )}
+                      {#case @infinite_scroll}
                         {#match infinite_scroll}
                           {#case Types.maybe_to_integer(e(@feed_filters, :time_limit, nil), 0)}
                             {#match time_limit}


### PR DESCRIPTION
﻿For bonfire-networks/bounties#2.

Moves feed load-more configuration lookups out of the Surface template and into the FeedLive assigns prepared by `ok_socket/1`. The rendered output and defaults stay the same, but the hot feed render path no longer calls `Config.get/3` and `Settings.get/3` while building the pagination controls.

Touched areas:
- FeedLive props for cached pagination settings
- FeedLive `ok_socket/1` assign preparation
- FeedLive Surface pagination template

Checked:
- `git diff --check HEAD~1..HEAD`

Could not run local Elixir formatting/tests in this Windows checkout:
- `mix` is not installed on PATH
- `just check-formatted` fails before running because this environment has no `/bin/bash`
