### PR TITLE
Render guest feed actions statelessly

### DIFF
--- a/lib/components/activity/actions/actions_live.ex
+++ b/lib/components/activity/actions/actions_live.ex
@@ -58,6 +58,11 @@ defmodule Bonfire.UI.Social.Activity.ActionsLive do
     e(replied, :nested_replies_count, 0) + e(replied, :direct_replies_count, 0)
   end
 
+  def stateless_actions?(context) do
+    is_nil(current_user_id(context)) ||
+      LiveHandler.feed_live_update_many_preload_mode() in [:async_actions, :inline]
+  end
+
   def the_activity(activity, object) do
     activity || e(object, :activity, nil) || object
   end

--- a/lib/components/activity/actions/actions_live.sface
+++ b/lib/components/activity/actions/actions_live.sface
@@ -117,7 +117,7 @@ data-show-plain-actions={!Settings.get(
           class="!flex btn lg:tooltip lg:tooltip-bottom btn-sm btn-ghost btn-circle group hover:bg-primary/10 transition-transform duration-150 ease-out hover:scale-105 active:scale-95 hover:-translate-y-0.5"
         />
 
-        {#if LiveHandler.feed_live_update_many_preload_mode() in [:async_actions, :inline]}
+        {#if stateless_actions?(@__context__)}
           <!-- LOAD ALL AS IF THEY WERE STATELESS COMPONENTS, since we preload data in this component -->
           <StatelessComponent
             :if={@showing_within != :messages}


### PR DESCRIPTION
## Summary

Small follow-up for bonfire-networks/bounties#2.

The feed render benchmark target is the local feed as a guest. In that path the activity action area does not need per-user reaction/bookmark state, but the current template still falls through to stateful reaction components unless `feed_live_update_many_preload_mode()` is `:async_actions` or `:inline`.

This changes `ActionsLive` so guest contexts use the existing stateless action rendering path. Public counts and object/boundary data are still passed through, while logged-in contexts keep the existing preload-mode behavior.

## Why

For a 20-activity guest feed, avoiding per-activity stateful reaction components should reduce LiveComponent setup/update work in the exact page shape described in the bounty. This is intentionally narrower than the broader settings/debug cleanup in #10 and can be reviewed independently.

## Validation

- `git diff --check` passes.
- `mix format --check-formatted ...` and `mix compile` could not be run in this local environment because `mix`/Elixir is not installed here.

