### PR TITLE
Prepare feed load-more state before rendering

### DIFF
--- a/lib/components/feeds/feed_live.ex
+++ b/lib/components/feeds/feed_live.ex
@@ -75,6 +75,22 @@ defmodule Bonfire.UI.Social.FeedLive do
   prop feed_count, :any, default: nil
   prop resumed_from_marker, :any, default: nil
   data jumping_to_newest, :boolean, default: false
+
+  data load_more, :map,
+    default: %{
+      cursor: nil,
+      infinite_scroll: nil,
+      current_url_with_time_limit: nil,
+      multiply_limit: nil,
+      time_limit: 0,
+      socket_connected: false,
+      show_older: false,
+      show_older_inline: false,
+      show_older_page_info: nil,
+      older_cursor: nil,
+      show_older_url: nil
+    }
+
   prop deferred_join_multiply_limit, :any, default: nil
   prop cute_gif, :any, default: nil
   prop custom_preview, :any, default: nil
@@ -143,6 +159,70 @@ defmodule Bonfire.UI.Social.FeedLive do
         e(entry, :object, :id, nil) || e(entry, :edge, :id, nil)
 
     entry_id && MapSet.member?(fresh_ids, entry_id)
+  end
+
+  defp load_more_state(assigns) do
+    page_info = e(assigns, :page_info, nil)
+    previous_page_info = e(assigns, :previous_page_info, nil)
+    context = e(assigns, :__context__, %{})
+    feed_filters = e(assigns, :feed_filters, nil)
+    deferred_join_multiply_limit = e(assigns, :deferred_join_multiply_limit, nil)
+    current_url = e(assigns, :current_url, nil) || e(context, :current_url, nil)
+
+    end_cursor = LoadMoreLive.end_cursor(page_info)
+
+    previous_end_cursor =
+      LoadMoreLive.end_cursor(previous_page_info) ||
+        e(context, :current_params, "Elixir.Bonfire.Social.Feeds", "after", nil) ||
+        e(context, :current_params, "after", nil)
+
+    final_end_cursor =
+      LoadMoreLive.final_cursor(page_info) || LoadMoreLive.final_cursor(previous_page_info)
+
+    query_with_deferred_join? =
+      (Config.get([Bonfire.Social.Feeds, :query_with_deferred_join], true,
+         name: l("Use Deferred Joins"),
+         description: l("Technical setting for query performance optimization.")
+       ) && is_nil(deferred_join_multiply_limit)) ||
+        (not is_nil(deferred_join_multiply_limit) && deferred_join_multiply_limit < 4)
+
+    infinite_scroll =
+      Settings.get([:ui, :infinite_scroll], :preload,
+        context: context,
+        name: l("Infinite Scrolling"),
+        description: l("Enable infinite scrolling in feeds, or choose a hybrid approach.")
+      )
+
+    time_limit = Types.maybe_to_integer(e(feed_filters, :time_limit, nil), 0)
+    sort_by = e(feed_filters, :sort_by, nil)
+    older_cursor = end_cursor || previous_end_cursor || final_end_cursor
+
+    %{
+      infinite_scroll: infinite_scroll,
+      time_limit: time_limit,
+      cursor:
+        end_cursor ||
+          if(query_with_deferred_join? && sort_by in [nil, :date_created],
+            do: final_end_cursor || previous_end_cursor
+          ),
+      current_url_with_time_limit:
+        if(current_url,
+          do:
+            append_params_uri(current_url, %{"#{Bonfire.Social.Feeds}[time_limit]" => time_limit})
+        ),
+      multiply_limit:
+        if(query_with_deferred_join?,
+          do: (deferred_join_multiply_limit || 2) * 2,
+          else: deferred_join_multiply_limit
+        ),
+      show_older: !e(assigns, :loading, nil) && time_limit != 0,
+      socket_connected: user_socket_connected?(context),
+      show_older_inline: (older_cursor && is_nil(sort_by)) || sort_by == :date_created,
+      show_older_page_info: page_info || previous_page_info,
+      older_cursor: older_cursor,
+      show_older_url:
+        if(current_url, do: append_params_uri(current_url, time_limit: 0, after: older_cursor))
+    }
   end
 
   def tabs(_page, context) do
@@ -406,28 +486,32 @@ defmodule Bonfire.UI.Social.FeedLive do
   defp ok_socket(socket) do
     # debug(assigns(socket)[:__context__][:current_params], "fsa")
 
+    socket =
+      socket
+      |> assign(
+        feed_component_id: assigns(socket)[:id],
+        hide_actions:
+          assigns(socket)[:hide_actions] ||
+            (Settings.get(
+               [
+                 Bonfire.UI.Social.Activity.ActionsLive,
+                 :feed,
+                 :hide_until_hovered
+               ],
+               nil,
+               current_user: current_user(socket),
+               name: l("Hide Activity Actions"),
+               description:
+                 l("Hide actions (such a like or boost) in feeds until users hover over them.")
+             ) && "until_hovered"),
+        hide_activities:
+          assigns(socket)[:hide_activities] ||
+            assigns(socket)[:__context__][:current_params]["hide_activities"]
+      )
+
     {:ok,
      socket
-     |> assign(
-       feed_component_id: assigns(socket)[:id],
-       hide_actions:
-         assigns(socket)[:hide_actions] ||
-           (Settings.get(
-              [
-                Bonfire.UI.Social.Activity.ActionsLive,
-                :feed,
-                :hide_until_hovered
-              ],
-              nil,
-              current_user: current_user(socket),
-              name: l("Hide Activity Actions"),
-              description:
-                l("Hide actions (such a like or boost) in feeds until users hover over them.")
-            ) && "until_hovered"),
-       hide_activities:
-         assigns(socket)[:hide_activities] ||
-           assigns(socket)[:__context__][:current_params]["hide_activities"]
-     )}
+     |> assign(:load_more, load_more_state(assigns(socket)))}
   end
 
   def maybe_subscribe(socket) do

--- a/lib/components/feeds/feed_live.sface
+++ b/lib/components/feeds/feed_live.sface
@@ -147,158 +147,105 @@
 
       {!-- Pagination: --}
 
-      {!-- # TODO: put these in a prepare function instead of so many cases in the markup --}
-      {#case LoadMoreLive.end_cursor(@page_info)}
-        {#match end_cursor}
-          {#case LoadMoreLive.end_cursor(@previous_page_info) ||
-              e(@__context__, :current_params, "Elixir.Bonfire.Social.Feeds", "after", nil) ||
-              e(@__context__, :current_params, "after", nil)}
-            {#match previous_end_cursor}
-              {#case LoadMoreLive.final_cursor(@page_info) || LoadMoreLive.final_cursor(@previous_page_info)}
-                {#match final_end_cursor}
-                  {#case (Config.get([Bonfire.Social.Feeds, :query_with_deferred_join], true,
-                       name: l("Use Deferred Joins"),
-                       description: l("Technical setting for query performance optimization.")
-                     ) &&
-                       !@deferred_join_multiply_limit) or @deferred_join_multiply_limit < 4}
-                    {#match query_with_deferred_join?}
-                      {#case Settings.get([:ui, :infinite_scroll], :preload,
-                          context: @__context__,
-                          name: l("Infinite Scrolling"),
-                          description: l("Enable infinite scrolling in feeds, or choose a hybrid approach.")
-                        )}
-                        {#match infinite_scroll}
-                          {#case Types.maybe_to_integer(e(@feed_filters, :time_limit, nil), 0)}
-                            {#match time_limit}
-                              {!-- context={@id} 
-                                cursor={end_cursor ||
-                                if previous_end_cursor && query_with_deferred_join?,
-                                          do: previous_end_cursor}
-                                    --}
-                              <LoadMoreLive
-                                :if={!@hide_load_more}
-                                live_handler={Bonfire.Social.Feeds}
-                                page_info={@page_info}
-                                cursor={end_cursor ||
-                                  if query_with_deferred_join? and e(@feed_filters, :sort_by, nil) in [nil, :date_created],
-                                    do: final_end_cursor || previous_end_cursor}
-                                infinite_scroll={infinite_scroll}
-                                target={@myself}
-                                entry_count={@feed_count}
-                                current_url={append_params_uri(
-                                  @current_url || @__context__[:current_url],
-                                  %{"#{Bonfire.Social.Feeds}[time_limit]" => time_limit}
-                                )}
-                                multiply_limit={if query_with_deferred_join?,
-                                  do: (@deferred_join_multiply_limit || 2) * 2,
-                                  else: @deferred_join_multiply_limit}
-                              >
-                                <:if_no_more>
-                                  {#if time_limit != 0}
-                                    <p class="text-sm py-4 mt-4 text-center text-base-content/50 font-medium">{lp(
-                                        "That's all for today...",
-                                        "That's all for the last %{number} days...",
-                                        time_limit,
-                                        number: time_limit
-                                      )}</p>
-                                  {#else}
-                                    {!-- {#if is_nil(@previous_page_info)} --}
-                                    {#if @loading}
-                                      <div class="flex flex-col items-center gap-3 py-12 place-content-center">
-                                        {#if user_socket_connected?(@__context__) && @cute_gif}
-                                          <div class="flex flex-row items-center justify-center my-12">
-                                            <img src={@cute_gif}>
-                                          </div>
-                                        {#else}
-                                          <img src={Bonfire.Common.URIs.static_path("/images/loading.svg")}>
-                                        {/if}
+      <LoadMoreLive
+        :if={!@hide_load_more}
+        live_handler={Bonfire.Social.Feeds}
+        page_info={@page_info}
+        cursor={@load_more.cursor}
+        infinite_scroll={@load_more.infinite_scroll}
+        target={@myself}
+        entry_count={@feed_count}
+        current_url={@load_more.current_url_with_time_limit}
+        multiply_limit={@load_more.multiply_limit}
+      >
+        <:if_no_more>
+          {#if @load_more.time_limit != 0}
+            <p class="text-sm py-4 mt-4 text-center text-base-content/50 font-medium">{lp(
+                "That's all for today...",
+                "That's all for the last %{number} days...",
+                @load_more.time_limit,
+                number: @load_more.time_limit
+              )}</p>
+          {#else}
+            {#if @loading}
+              <div class="flex flex-col items-center gap-3 py-12 place-content-center">
+                {#if @load_more.socket_connected && @cute_gif}
+                  <div class="flex flex-row items-center justify-center my-12">
+                    <img src={@cute_gif}>
+                  </div>
+                {#else}
+                  <img src={Bonfire.Common.URIs.static_path("/images/loading.svg")}>
+                {/if}
 
-                                        <div class="sr-only text-base-content">{l("Loading...")}</div>
-                                      </div>
-                                    {#elseif not is_integer(@feed_count) or @feed_count == 0}
-                                      <div data-id="empty-feed" class="flex items-center place-content-center">
-                                        <Bonfire.UI.Common.EmptyFeed
-                                          feed_name={@feed_name}
-                                          feedback_title={@feedback_title}
-                                          feedback_message={@feedback_message}
-                                        />
-                                        {!-- empty_feed={@bottom_or_empty_feed} --}
-                                      </div>
-                                    {#else}
-                                      <img
-                                        class="max-w-[220px] opacity-80 mx-auto"
-                                        src={Bonfire.Common.URIs.static_path("/images/bonfire-exausted.png")}
-                                      />
-                                      <p class="text-sm font-medium text-base-content/70 text-center my-4">{l("That's all folks...")}</p>
-                                    {/if}
-                                  {/if}
+                <div class="sr-only text-base-content">{l("Loading...")}</div>
+              </div>
+            {#elseif not is_integer(@feed_count) or @feed_count == 0}
+              <div data-id="empty-feed" class="flex items-center place-content-center">
+                <Bonfire.UI.Common.EmptyFeed
+                  feed_name={@feed_name}
+                  feedback_title={@feedback_title}
+                  feedback_message={@feedback_message}
+                />
+              </div>
+            {#else}
+              <img
+                class="max-w-[220px] opacity-80 mx-auto"
+                src={Bonfire.Common.URIs.static_path("/images/bonfire-exausted.png")}
+              />
+              <p class="text-sm font-medium text-base-content/70 text-center my-4">{l("That's all folks...")}</p>
+            {/if}
+          {/if}
 
-                                  {#if !@loading |> debug("loaad") and time_limit != 0}
-                                    {#if user_socket_connected?(@__context__) |> debug("soo")}
-                                      {#if ((debug(end_cursor, "ecc") || previous_end_cursor |> debug("pec") || final_end_cursor)
-                                         |> debug("acc") && !debug(e(@feed_filters, :sort_by, nil), "sbb")) ||
-                                          e(@feed_filters, :sort_by, nil) == :date_created}
-                                        {!-- we are sorting by date and can simply continue paginating but with no limit --}
-                                        {!-- TODO: instead of switching to infinity, switch 1 level up from current limit, eg. from 1 week to 1 month --}
-                                        <LoadMoreLive
-                                          live_handler={Bonfire.Social.Feeds}
-                                          page_info={@page_info || @previous_page_info}
-                                          cursor={end_cursor || previous_end_cursor || final_end_cursor}
-                                          infinite_scroll={infinite_scroll}
-                                          target={@myself}
-                                          hide_guest_fallback={@hide_guest_fallback}
-                                          label={l("Show older activities")}
-                                          dom_id_suffix="show_older"
-                                          opts={%{"phx-value-time_limit" => 0}}
-                                          hide_if_no_more
-                                          current_url={@current_url}
-                                        />
-                                      {#else}
-                                        {!-- do we need to reload the feed if not sorting by date? --}
-                                        <div class="w-full flex items-center justify-center mb-4">
-                                          <button
-                                            data-id="load_all_time"
-                                            class="normal-case btn btn-soft btn-primary"
-                                            phx-click="set_filter"
-                                            phx-value-time_limit={0}
-                                            phx-target={@myself}
-                                            phx-disable-with={l("Loading...")}
-                                          >
-                                            {l("Show all activities (with no time limit)")}
-                                          </button>
-                                        </div>
-                                      {/if}
-                                    {#else}
-                                      {!-- no socket connected --}
-                                      <div class="w-full flex items-center justify-center mb-4">
-                                        <a
-                                          :if={!@hide_guest_fallback}
-                                          data-id="load_all_time"
-                                          class="normal-case btn btn-primary btn-soft btn-wide"
-                                          href={append_params_uri(
-                                            @current_url || @__context__[:current_url],
-                                            time_limit: 0,
-                                            after: end_cursor || previous_end_cursor || final_end_cursor
-                                          )}
-                                        >
-                                          {l("Show older activities")}
-                                        </a>
-                                      </div>
-                                    {/if}
-                                  {/if}
+          {#if @load_more.show_older}
+            {#if @load_more.socket_connected}
+              {#if @load_more.show_older_inline}
+                <LoadMoreLive
+                  live_handler={Bonfire.Social.Feeds}
+                  page_info={@load_more.show_older_page_info}
+                  cursor={@load_more.older_cursor}
+                  infinite_scroll={@load_more.infinite_scroll}
+                  target={@myself}
+                  hide_guest_fallback={@hide_guest_fallback}
+                  label={l("Show older activities")}
+                  dom_id_suffix="show_older"
+                  opts={%{"phx-value-time_limit" => 0}}
+                  hide_if_no_more
+                  current_url={@current_url}
+                />
+              {#else}
+                <div class="w-full flex items-center justify-center mb-4">
+                  <button
+                    data-id="load_all_time"
+                    class="normal-case btn btn-soft btn-primary"
+                    phx-click="set_filter"
+                    phx-value-time_limit={0}
+                    phx-target={@myself}
+                    phx-disable-with={l("Loading...")}
+                  >
+                    {l("Show all activities (with no time limit)")}
+                  </button>
+                </div>
+              {/if}
+            {#else}
+              <div class="w-full flex items-center justify-center mb-4">
+                <a
+                  :if={!@hide_guest_fallback}
+                  data-id="load_all_time"
+                  class="normal-case btn btn-primary btn-soft btn-wide"
+                  href={@load_more.show_older_url}
+                >
+                  {l("Show older activities")}
+                </a>
+              </div>
+            {/if}
+          {/if}
 
-                                  <div :if={@bottom_or_empty_feed} class="mt-1 mb-2 text-center text-base-content">
-                                    <#slot {@bottom_or_empty_feed}>
-                                    </#slot>
-                                  </div>
-                                </:if_no_more>
-                              </LoadMoreLive>
-                          {/case}
-                      {/case}
-                  {/case}
-              {/case}
-          {/case}
-      {/case}
+          <div :if={@bottom_or_empty_feed} class="mt-1 mb-2 text-center text-base-content">
+            <#slot {@bottom_or_empty_feed}>
+            </#slot>
+          </div>
+        </:if_no_more>
+      </LoadMoreLive>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Small focused contribution toward bonfire-networks/bounties#2.

This moves the feed pagination/load-more state that was being recomputed inside `FeedLive.sface` into `FeedLive.load_more_state/1`, then renders from the prepared assign. It keeps the existing branching behavior but avoids repeated template calls for cursor extraction, deferred-join settings, infinite-scroll settings, time-limit coercion, socket-connected checks, and fallback URL generation.

It also removes the remaining debug calls in that load-more branch.

## Why

The rendering bounty benchmark targets the local feed page. The existing template had a TODO to move this work into a prepare function, and the no-more/load-older branch sits on the feed render path. Preparing the state once makes the template cheaper and easier to reason about without changing the feed query or activity/action rendering paths already covered by other open PRs.

## Validation

- `git diff --check`
- Parsed `lib/components/feeds/feed_live.ex` with Elixir 1.18 in Docker: `Code.string_to_quoted!(File.read!("lib/components/feeds/feed_live.ex"))`

I could not run the project formatter, compile, or benchmark in this checkout because the host does not have Elixir/Mix/just installed, and `mix format` in a standalone Elixir Docker image fails while loading the project dependency helper before dependencies are available. Maintainer campground benchmark is still needed for real performance validation.