### PR TITLE
Cache feed preload mode through render path

### DIFF
--- a/lib/components/activity/actions/actions_live.ex
+++ b/lib/components/activity/actions/actions_live.ex
@@ -36,6 +36,7 @@ defmodule Bonfire.UI.Social.Activity.ActionsLive do
   prop my_boost, :any, default: nil
   prop my_like, :any, default: nil
   prop my_bookmark, :any, default: nil
+  prop feed_live_update_many_preload_mode, :atom, default: nil
 
   # @decorate time()
   def update_many(assigns_sockets) do
@@ -57,6 +58,11 @@ defmodule Bonfire.UI.Social.Activity.ActionsLive do
     # debug(replied)
     e(replied, :nested_replies_count, 0) + e(replied, :direct_replies_count, 0)
   end
+
+  def preloaded_actions?(nil),
+    do: LiveHandler.feed_live_update_many_preload_mode() in [:async_actions, :inline]
+
+  def preloaded_actions?(mode), do: mode in [:async_actions, :inline]
 
   def the_activity(activity, object) do
     activity || e(object, :activity, nil) || object

--- a/lib/components/activity/actions/actions_live.sface
+++ b/lib/components/activity/actions/actions_live.sface
@@ -117,7 +117,7 @@ data-show-plain-actions={!Settings.get(
           class="!flex btn lg:tooltip lg:tooltip-bottom btn-sm btn-ghost btn-circle group hover:bg-primary/10 transition-transform duration-150 ease-out hover:scale-105 active:scale-95 hover:-translate-y-0.5"
         />
 
-        {#if LiveHandler.feed_live_update_many_preload_mode() in [:async_actions, :inline]}
+        {#if preloaded_actions?(@feed_live_update_many_preload_mode)}
           <!-- LOAD ALL AS IF THEY WERE STATELESS COMPONENTS, since we preload data in this component -->
           <StatelessComponent
             :if={@showing_within != :messages}

--- a/lib/components/activity/activity_live.ex
+++ b/lib/components/activity/activity_live.ex
@@ -69,6 +69,7 @@ defmodule Bonfire.UI.Social.ActivityLive do
   prop quotes, :list, default: []
   prop hashtags, :list, default: []
   prop autoplay, :any, default: nil
+  prop feed_live_update_many_preload_mode, :atom, default: nil
 
   def update_many(assigns_sockets) do
     assigns_sockets
@@ -1120,7 +1121,10 @@ defmodule Bonfire.UI.Social.ActivityLive do
                      ]}
                 {#if @hide_activity != "actions" and @hide_actions != true}
                   {#if user_socket_connected?(@__context__) &&
-                      LiveHandler.feed_live_update_many_preload_mode() in [:async_actions, :inline]}
+                      effective_feed_live_update_many_preload_mode(@feed_live_update_many_preload_mode) in [
+                        :async_actions,
+                        :inline
+                      ]}
                     <StatefulComponent
                       id={"#{@activity_component_id}_actions"}
                       module={component}
@@ -1152,6 +1156,7 @@ defmodule Bonfire.UI.Social.ActivityLive do
                         e(@object, :creator, nil) || e(@activity, :subject, nil)}
                       participants={@participants}
                       quotes={@quotes}
+                      feed_live_update_many_preload_mode={@feed_live_update_many_preload_mode}
                     />
                   {#else}
                     <StatelessComponent
@@ -1182,6 +1187,7 @@ defmodule Bonfire.UI.Social.ActivityLive do
                         e(maybe_get(component_assigns, :activity, @activity), :created, :creator, nil) ||
                         e(maybe_get(component_assigns, :object, @object), :creator, nil) ||
                         e(maybe_get(component_assigns, :activity, @activity), :subject, nil)}
+                      feed_live_update_many_preload_mode={@feed_live_update_many_preload_mode}
                     />
                   {/if}
                 {/if}
@@ -1244,6 +1250,11 @@ defmodule Bonfire.UI.Social.ActivityLive do
     <div />
     """
   end
+
+  def effective_feed_live_update_many_preload_mode(nil),
+    do: LiveHandler.feed_live_update_many_preload_mode()
+
+  def effective_feed_live_update_many_preload_mode(mode), do: mode
 
   # def show_minimal_reply?(object, activity, showing_within) do
   #   (e(object, :post_content, nil) != nil and showing_within == :smart_input) or

--- a/lib/components/feeds/feed_live.ex
+++ b/lib/components/feeds/feed_live.ex
@@ -75,6 +75,7 @@ defmodule Bonfire.UI.Social.FeedLive do
   prop feed_count, :any, default: nil
   prop resumed_from_marker, :any, default: nil
   data jumping_to_newest, :boolean, default: false
+  data feed_live_update_many_preload_mode, :atom, default: nil
   prop deferred_join_multiply_limit, :any, default: nil
   prop cute_gif, :any, default: nil
   prop custom_preview, :any, default: nil
@@ -426,7 +427,8 @@ defmodule Bonfire.UI.Social.FeedLive do
             ) && "until_hovered"),
        hide_activities:
          assigns(socket)[:hide_activities] ||
-           assigns(socket)[:__context__][:current_params]["hide_activities"]
+           assigns(socket)[:__context__][:current_params]["hide_activities"],
+       feed_live_update_many_preload_mode: LiveHandler.feed_live_update_many_preload_mode()
      )}
   end
 

--- a/lib/components/feeds/feed_live.sface
+++ b/lib/components/feeds/feed_live.sface
@@ -138,6 +138,7 @@
                     hide_activity={@hide_activities}
                     subject_user={@subject_user}
                     activity_preloads={@activity_preloads}
+                    feed_live_update_many_preload_mode={@feed_live_update_many_preload_mode}
                   />
               {/case}
             </div>

--- a/lib/live_handlers/feeds_live_handler.ex
+++ b/lib/live_handlers/feeds_live_handler.ex
@@ -1623,7 +1623,7 @@ defmodule Bonfire.Social.Feeds.LiveHandler do
     feed_live_update_many_preload_mode = feed_live_update_many_preload_mode()
 
     override_live_update_many_preload_mode =
-      case feed_live_update_many_preload_mode() do
+      case feed_live_update_many_preload_mode do
         # we also want to do other preloads inline
         :async_actions -> :inline
         other -> other
@@ -1705,7 +1705,9 @@ defmodule Bonfire.Social.Feeds.LiveHandler do
 
   @decorate time()
   def actions_update_many(assigns_sockets, opts) do
-    if feed_live_update_many_preload_mode() in [:async_actions, :inline] do
+    feed_live_update_many_preload_mode = feed_live_update_many_preload_mode()
+
+    if feed_live_update_many_preload_mode in [:async_actions, :inline] do
       {first_assigns, _} = List.first(assigns_sockets)
 
       opts =
@@ -1713,7 +1715,7 @@ defmodule Bonfire.Social.Feeds.LiveHandler do
           return_assigns_socket_tuple: true,
           preload_status_key: :preloaded_async_actions,
           live_update_many_preload_mode:
-            if(feed_live_update_many_preload_mode() == :inline,
+            if(feed_live_update_many_preload_mode == :inline,
               do: :inline,
               else: :user_async_or_skip
             ),

--- a/lib/live_handlers/feeds_live_handler.ex
+++ b/lib/live_handlers/feeds_live_handler.ex
@@ -1620,7 +1620,8 @@ defmodule Bonfire.Social.Feeds.LiveHandler do
 
   @decorate time()
   def activity_update_many(assigns_sockets, opts) do
-    feed_live_update_many_preload_mode = feed_live_update_many_preload_mode()
+    {first_assigns, _} = List.first(assigns_sockets)
+    feed_live_update_many_preload_mode = feed_live_update_many_preload_mode(first_assigns)
 
     override_live_update_many_preload_mode =
       case feed_live_update_many_preload_mode do
@@ -1630,8 +1631,6 @@ defmodule Bonfire.Social.Feeds.LiveHandler do
       end
 
     # |> debug("feed_live_update_many_preload_mode")
-
-    {first_assigns, _} = List.first(assigns_sockets)
 
     opts =
       Keyword.merge(opts,
@@ -1705,11 +1704,10 @@ defmodule Bonfire.Social.Feeds.LiveHandler do
 
   @decorate time()
   def actions_update_many(assigns_sockets, opts) do
-    feed_live_update_many_preload_mode = feed_live_update_many_preload_mode()
+    {first_assigns, _} = List.first(assigns_sockets)
+    feed_live_update_many_preload_mode = feed_live_update_many_preload_mode(first_assigns)
 
     if feed_live_update_many_preload_mode in [:async_actions, :inline] do
-      {first_assigns, _} = List.first(assigns_sockets)
-
       opts =
         Keyword.merge(opts,
           return_assigns_socket_tuple: true,
@@ -1771,6 +1769,11 @@ defmodule Bonfire.Social.Feeds.LiveHandler do
       assigns_sockets
     end
   end
+
+  defp feed_live_update_many_preload_mode(%{} = assigns),
+    do: assigns[:feed_live_update_many_preload_mode] || feed_live_update_many_preload_mode()
+
+  defp feed_live_update_many_preload_mode(_assigns), do: feed_live_update_many_preload_mode()
 
   def feed_live_update_many_preload_mode,
     do:


### PR DESCRIPTION
## Summary

Small focused contribution toward bonfire-networks/bounties#2.

This caches `feed_live_update_many_preload_mode` once on the feed render path, passes it through `ActivityLive` into `ActionsLive`, and reuses the already-resolved mode inside the feed live handler. The update handlers now also prefer the mode already present in component assigns before falling back to the global resolver, so feed `update_many` batches do not need to resolve the same process/config setting again.

The existing fallback behavior is kept for activity/action renders that are not coming from `FeedLive`.

## Why

The activity/action templates and handler were resolving `LiveHandler.feed_live_update_many_preload_mode/0` repeatedly while rendering or updating a feed. That resolver reads process/config state and pipes through `debug/1`, so the local-feed page pays that cost more than once across the render/update path.

This keeps the mode stable for a feed render/update cycle and avoids repeated lookups in the hot path without changing which rendering mode is selected.

## Validation

- `git diff --check`
- `git diff --cached --check` before commit

I could not run the project formatter, compile, or campground benchmark locally because this machine does not have Elixir/Mix/Just/Docker available. This should be reviewed as a narrow render-path cleanup, not a standalone threshold claim.