### PR TITLE
perf: cache current user id during activity rendering

### DIFF
--- a/lib/components/activity/activity_live.ex
+++ b/lib/components/activity/activity_live.ex
@@ -771,6 +771,11 @@ defmodule Bonfire.UI.Social.ActivityLive do
         do: maybe_prepare(assigns),
         else: assigns
 
+    # Cache the current user id once per activity render. The feed template and
+    # subject components may check it many times while rendering a list of
+    # activities; doing the context lookup once keeps those checks cheap.
+    assigns = Map.put(assigns, :current_user_id, current_user_id(assigns[:__context__]))
+
     ~F"""
     <article
       id={@activity_component_id || "activity-unprepared-#{@activity_id || Text.random_string()}"}
@@ -824,7 +829,7 @@ defmodule Bonfire.UI.Social.ActivityLive do
       {!-- Preview click trigger (hidden `.open_preview_link`) — rendered alongside
            both the default activity content and any `@custom_preview`, so that
            clicking the article opens the PreviewContentLive modal in either case. --}
-      {#if @hide_activity != "all" and not is_nil(current_user_id(@__context__)) and
+      {#if @hide_activity != "all" and not is_nil(@current_user_id) and
           @showing_within not in [:smart_input, :thread, :widget, :nested_preview]}
         {!-- TODO: make the list of preview paths/components/views configurable/hookable, and derive the view from object_type? and compute object_type not just based on schema, but also with some logic looking at fields (eg. action=="work") --}
         {#if String.starts_with?(@permalink || "", ["/post/", "/discussion/", "/discuss/"])}
@@ -923,18 +928,18 @@ defmodule Bonfire.UI.Social.ActivityLive do
           <form
             :if={!id(e(@activity, :seen, nil)) and not is_nil(@feed_id) and
               @showing_within in [:messages, :notifications] and
-              current_user_id(@__context__) !=
+              @current_user_id !=
                 (e(@object, :created, :creator_id, nil) || e(@activity, :subject, :id, nil))}
-            x-init={if @feed_id && current_user_id(@__context__),
+            x-init={if @feed_id && @current_user_id,
               do:
                 "if ($el.getBoundingClientRect().top < window.innerHeight && $el.getBoundingClientRect().bottom > 0) {
                 $el.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
                 $el.parentNode.classList.remove('unread-activity');
               }"}
-            x-intersect.once.full={if @feed_id && current_user_id(@__context__),
+            x-intersect.once.full={if @feed_id && @current_user_id,
               do:
                 "$el.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true})); $el.parentNode.classList.remove('unread-activity');"}
-            phx-submit={if @feed_id && current_user_id(@__context__), do: "Bonfire.Social.Feeds:mark_seen"}
+            phx-submit={if @feed_id && @current_user_id, do: "Bonfire.Social.Feeds:mark_seen"}
             phx-target={if @feed_id, do: "#unseen_count_#{@feed_id}"}
           >
             <input type="hidden" name="feed_id" value={@feed_id}>
@@ -1028,6 +1033,7 @@ defmodule Bonfire.UI.Social.ActivityLive do
                   is_remote={@is_remote}
                   thread_title={maybe_get(component_assigns, :thread_title, @thread_title)}
                   subject_user={@subject_user}
+                  current_user_id={@current_user_id}
                   show_minimal_subject_and_note={maybe_get(component_assigns, :show_minimal_subject_and_note, @show_minimal_subject_and_note)}
                   request={e(maybe_get(component_assigns, :activity, @activity), :edge, :request, nil)}
                   extra_info={e(@object, :extra_info, nil)}

--- a/lib/components/activity/subject/no_subject_live.ex
+++ b/lib/components/activity/subject/no_subject_live.ex
@@ -3,6 +3,7 @@ defmodule Bonfire.UI.Social.Activity.NoSubjectLive do
 
   prop activity_id, :any, default: nil
   prop object_id, :any, default: nil
+  prop current_user_id, :any, default: nil
   prop peered, :any, default: nil
   # prop profile, :any, default: nil
   # prop character, :any, default: nil

--- a/lib/components/activity/subject/subject_live.ex
+++ b/lib/components/activity/subject/subject_live.ex
@@ -17,6 +17,7 @@ defmodule Bonfire.UI.Social.Activity.SubjectLive do
   prop subject_id, :any, default: nil
   prop object_id, :any, default: nil
   prop subject_user, :any, default: nil
+  prop current_user_id, :any, default: nil
 
   prop subject_peered, :any, default: nil
   prop peered, :any, default: nil

--- a/lib/components/activity/subject/subject_live.sface
+++ b/lib/components/activity/subject/subject_live.sface
@@ -72,8 +72,8 @@
     >
       <:actions>
         <div
-          :if={current_user_id(@__context__) &&
-            current_user_id(@__context__) != @subject_id}
+          :if={@current_user_id &&
+            @current_user_id != @subject_id}
           class="p-3 pt-1 items-center"
         >
           <StatefulComponent

--- a/lib/components/activity/subject/subject_minimal_live.ex
+++ b/lib/components/activity/subject/subject_minimal_live.ex
@@ -23,6 +23,7 @@ defmodule Bonfire.UI.Social.Activity.SubjectMinimalLive do
   prop thread_title, :any, default: nil
   prop published_in, :any, default: nil
   prop subject_id, :any, default: nil
+  prop current_user_id, :any, default: nil
   # prop subject_user, :any, default: nil
   prop subjects_more, :list, default: []
   prop profile_name, :string, default: nil

--- a/lib/components/activity/subject/subject_minimal_live.sface
+++ b/lib/components/activity/subject/subject_minimal_live.sface
@@ -104,11 +104,11 @@
           {#elseif @verb == "Boost"}
             {l("boosted your activity")}
           {#elseif @verb == "Follow"}
-            {if @object_id == current_user_id(@__context__),
+            {if @object_id == @current_user_id,
               do: l("followed you"),
               else: l("followed")}
           {#elseif @verb == "Request to Follow"}
-            {if @object_id == current_user_id(@__context__),
+            {if @object_id == @current_user_id,
               do: l("requested to follow you"),
               else: l("requested to follow")}
           {#elseif @verb == "Request to Quote"}
@@ -168,7 +168,7 @@
                 {@profile_name || @character_username}
               </LinkLive>
 
-              {if @object_id == current_user_id(@__context__),
+              {if @object_id == @current_user_id,
                 do: l("requested to follow you"),
                 else: "requested to follow"}
             </div>
@@ -184,7 +184,7 @@
               opts={"data-id": "subject_name"}
               parent_id={deterministic_dom_id(__MODULE__, @subject_id, "subject_minimal_name", @parent_id)}
             >
-              {#if @object_id == current_user_id(@__context__)}
+              {#if @object_id == @current_user_id}
                 {l("You")}
               {#else}
                 {@profile_name || @character_username}
@@ -207,7 +207,7 @@
                       opts={"data-id": "subject_name"}
                       parent_id={deterministic_dom_id(__MODULE__, @subject_id, "subject_minimal_name", @parent_id)}
                     >
-                      {#if @object_id == current_user_id(@__context__) || @subject_id == current_user_id(@__context__)}
+                      {#if @object_id == @current_user_id || @subject_id == @current_user_id}
                         {l("You")}
                       {#else}
                         {@profile_name || @character_username}
@@ -229,7 +229,7 @@
                       opts={"data-id": "subject_name"}
                       parent_id={deterministic_dom_id(__MODULE__, @subject_id, "subject_minimal_name", @parent_id)}
                     >
-                      {#if @object_id == current_user_id(@__context__) || @subject_id == current_user_id(@__context__)}
+                      {#if @object_id == @current_user_id || @subject_id == @current_user_id}
                         {l("You")}
                       {#else}
                         {@profile_name || @character_username}
@@ -270,7 +270,7 @@
                       parent_id={deterministic_dom_id(__MODULE__, @subject_id, "subject_minimal_name", @parent_id)}
                       class="link link-hover font-bold"
                     >
-                      {#if @object_id == current_user_id(@__context__)}
+                      {#if @object_id == @current_user_id}
                         {l("you")}
                       {#else}
                         {@profile_name || @character_username}
@@ -314,7 +314,7 @@
 
               {raw(@verb_display)}
 
-              <span :if={@object_id == current_user_id(@__context__)}>
+              <span :if={@object_id == @current_user_id}>
                 {!-- special case when current_user is the one being followed --}
                 {l("you")}
               </span>
@@ -363,7 +363,7 @@
                   parent_id={deterministic_dom_id(__MODULE__, @subject_id, "subject_minimal_name", @parent_id)}
                   class="link link-hover font-bold"
                 >
-                  {#if @object_id == current_user_id(@__context__)}
+                  {#if @object_id == @current_user_id}
                     {l("you")}
                   {#else}
                     {@profile_name || @character_username}


### PR DESCRIPTION
For bonfire-networks/bounties#2.

## Summary

Small focused render-path contribution for activity/subject rendering:

- Cache `current_user_id(@__context__)` once per `ActivityLive.render/1`.
- Reuse the cached `@current_user_id` in the activity template for preview/seen-form checks.
- Pass the cached value into subject components so repeated "is this me?" checks in `SubjectMinimalLive` and `SubjectLive` don't re-read the context multiple times per activity.

This is intentionally separate from the existing PRs that trim debug calls, guest actions, load-more state, and feed preload mode. It targets another repeated hot-path lookup in feed/activity rendering while preserving the same UI decisions.

## Validation

- Parsed changed `.ex` files with Elixir 1.18.4 / OTP 27 using `Code.string_to_quoted!/1`.
- Ran `git diff --check`.
- Verified the touched activity/subject templates no longer contain `current_user_id(@__context__)`; they render from `@current_user_id` instead.

I could not run the full Bonfire campground benchmark in this standalone extension checkout because the local environment does not include the full app/runtime setup, so this is submitted as a narrow contribution toward the feed rendering bounty rather than a standalone threshold claim.
